### PR TITLE
Devengage 2919 blank list serialization

### DIFF
--- a/yeast-markdown-renderer/dist/index.js
+++ b/yeast-markdown-renderer/dist/index.js
@@ -380,7 +380,7 @@ class MarkdownRenderer {
             if (!!rendered)
                 return rendered;
             rendered = this.renderComponent(node, this.defaultRenderers);
-            if (!!rendered)
+            if (rendered == '' || !!rendered)
                 return rendered;
             if (!rendered && this.unhandledNodeRenderer) {
                 rendered = this.unhandledNodeRenderer(node, this);

--- a/yeast-markdown-renderer/package-lock.json
+++ b/yeast-markdown-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "yeast-markdown-renderer",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "yeast-markdown-renderer",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^21.0.3",

--- a/yeast-markdown-renderer/package.json
+++ b/yeast-markdown-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeast-markdown-renderer",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "The yeast markdown renderer project provides a class to render yeast documents in markdown ",
 	"exports": {
 		"require": "./src/index.ts",

--- a/yeast-markdown-renderer/src/MarkdownRenderer.ts
+++ b/yeast-markdown-renderer/src/MarkdownRenderer.ts
@@ -132,7 +132,7 @@ export class MarkdownRenderer {
 			if (!!rendered) return rendered;
 
 			rendered = this.renderComponent(node, this.defaultRenderers);
-			if (rendered == '' || !!rendered) return rendered;
+			if (rendered === '' || !!rendered) return rendered;
 
 			if (!rendered && this.unhandledNodeRenderer) {
 				rendered = this.unhandledNodeRenderer(node, this);

--- a/yeast-markdown-renderer/src/MarkdownRenderer.ts
+++ b/yeast-markdown-renderer/src/MarkdownRenderer.ts
@@ -132,7 +132,7 @@ export class MarkdownRenderer {
 			if (!!rendered) return rendered;
 
 			rendered = this.renderComponent(node, this.defaultRenderers);
-			if (!!rendered) return rendered;
+			if (rendered == '' || !!rendered) return rendered;
 
 			if (!rendered && this.unhandledNodeRenderer) {
 				rendered = this.unhandledNodeRenderer(node, this);

--- a/yeast-markdown-renderer/src/__tests__/resources/LIST_DATA.ts
+++ b/yeast-markdown-renderer/src/__tests__/resources/LIST_DATA.ts
@@ -74,3 +74,50 @@ export const LIST_DATA = {
 		},
 	],
 };
+
+export const EMPTY_ITEM_LIST = {
+	type: 'document',
+	title: 'Default Page Title',
+	children: [
+		{
+			type: 'list',
+			children: [
+				{
+					type: 'listitem',
+					level: 0,
+					children: [
+						{
+							text: 'item',
+						},
+					],
+				},
+				{
+					type: 'listitem',
+					level: 0,
+					children: [
+						{
+							text: ' ',
+						},
+					],
+				},
+				{
+					type: 'listitem',
+					level: 0,
+					children: [
+						{
+							text: '',
+						},
+					],
+				},
+			],
+			ordered: false,
+			level: 0,
+		},
+	],
+};
+
+export const EMPTY_ITEM_LIST_RESULT = `
+- item
+-  
+- 
+`;

--- a/yeast-markdown-renderer/src/__tests__/tests/YeastMarkdownRenderer.test.ts
+++ b/yeast-markdown-renderer/src/__tests__/tests/YeastMarkdownRenderer.test.ts
@@ -2,7 +2,7 @@ import { DocumentNode, isYeastTextNode, isYeastNode, YeastChild, YeastNode, Yeas
 import { MarkdownRenderer } from '../../MarkdownRenderer';
 import { GENERAL_DATA } from '../resources/GENERAL_DATA';
 import { TABLE_DATA } from '../resources/TABLE_DATA';
-import { LIST_DATA } from '../resources/LIST_DATA';
+import { EMPTY_ITEM_LIST, EMPTY_ITEM_LIST_RESULT, LIST_DATA } from '../resources/LIST_DATA';
 import { SIMPLE_TABLE_AST, SIMPLE_TABLE_MARKDOWN } from '../resources/SIMPLE_TABLE';
 import { INLINE_CODE_AST, INLINE_CODE_MARKDOWN } from '../resources/INLINE_CODE_DATA';
 import { UNDEFINED_DATA_AST, UNDEFINED_DATA_MARKDOWN } from '../resources/UNDEFINED_DATA';
@@ -171,4 +171,11 @@ test('undefined in required prop', () => {
 test('image alt element undefined', () => {
 	const markdownString = new MarkdownRenderer().renderMarkdown(IMAGE_DATA_AST as DocumentNode);
 	expect(markdownString.trim()).toEqual(IMAGE_DATA_MARKDOWN.trim());
+});
+
+test('empty list with space and no space should be same', async () => {
+	const markdownRenderer = new MarkdownRenderer();
+	const listAst = EMPTY_ITEM_LIST as DocumentNode;
+	const listMarkdown = markdownRenderer.renderComponents(listAst.children).join('\n');
+	expect(listMarkdown).toEqual(EMPTY_ITEM_LIST_RESULT);
 });


### PR DESCRIPTION
This change addresses an inconsistency in handling blank list items: 

Previously, a list item containing only a space (' ') would return true due to double negation, while an empty string ('') would return false. This change implements a direct check to ensure consistent behavior for both cases.