### PR TITLE
DEVENGAGE-3011 Code fence crash

### DIFF
--- a/yeast-markdown-renderer/dist/index.js
+++ b/yeast-markdown-renderer/dist/index.js
@@ -30,8 +30,8 @@ function renderCustomComponent(node) {
     return `\n${root.end({ prettyPrint: true })}\n`;
 }
 
-const LITERAL_BACKTICK_REGEX = /((?:^|\n+)(?:\t+|\s+)*)(`{3})/ig;
-const LITERAL_TILDE_REGEX = /((?:^|\n+)(?:\t+|\s+)*)(~{3})/ig;
+const LITERAL_BACKTICK_REGEX = /((?:^|\n+)(?:\t|\s)*)(`{3})/ig;
+const LITERAL_TILDE_REGEX = /((?:^|\n+)(?:\t|\s)*)(~{3})/ig;
 function renderBlockCodeNode(node, renderer) {
     const jsonOptions = {
         title: node.title,

--- a/yeast-markdown-renderer/package-lock.json
+++ b/yeast-markdown-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "yeast-markdown-renderer",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "yeast-markdown-renderer",
-			"version": "1.2.3",
+			"version": "1.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^21.0.3",

--- a/yeast-markdown-renderer/package.json
+++ b/yeast-markdown-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeast-markdown-renderer",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "The yeast markdown renderer project provides a class to render yeast documents in markdown ",
 	"exports": {
 		"require": "./src/index.ts",

--- a/yeast-markdown-renderer/src/YeastNodeTypes/BlockCodeNode.ts
+++ b/yeast-markdown-renderer/src/YeastNodeTypes/BlockCodeNode.ts
@@ -2,8 +2,8 @@ import { MarkdownRenderer } from '../MarkdownRenderer';
 import { BlockCodeNode } from 'yeast-core';
 
 // Matches case when codeblock content is a literal codeblock example
-const LITERAL_BACKTICK_REGEX = /((?:^|\n+)(?:\t+|\s+)*)(`{3})/ig;
-const LITERAL_TILDE_REGEX = /((?:^|\n+)(?:\t+|\s+)*)(~{3})/ig;
+const LITERAL_BACKTICK_REGEX = /((?:^|\n+)(?:\t|\s)*)(`{3})/ig;
+const LITERAL_TILDE_REGEX = /((?:^|\n+)(?:\t|\s)*)(~{3})/ig;
 
 export default function renderBlockCodeNode(node: BlockCodeNode, renderer: MarkdownRenderer) {
 	const jsonOptions = {

--- a/yeast-markdown-renderer/src/__tests__/resources/BLOCKCODE_DATA.ts
+++ b/yeast-markdown-renderer/src/__tests__/resources/BLOCKCODE_DATA.ts
@@ -1,0 +1,14 @@
+export const BLOCKCODE_DATA = {
+	type: 'document',
+	title: 'Testing indentation in block code node',
+	author: 'yuri.yetina',
+	children: [
+        {
+            type: "code",
+            children: [],
+            value: "val chatController = ChatController.Builder(context)\n                                                    .build(messengerAccount, ChatLoadedListener)",
+            language: "",
+            indentation: 0
+        }
+    ],
+};

--- a/yeast-markdown-renderer/src/__tests__/tests/YeastMarkdownRenderer.test.ts
+++ b/yeast-markdown-renderer/src/__tests__/tests/YeastMarkdownRenderer.test.ts
@@ -8,6 +8,7 @@ import { INLINE_CODE_AST, INLINE_CODE_MARKDOWN } from '../resources/INLINE_CODE_
 import { UNDEFINED_DATA_AST, UNDEFINED_DATA_MARKDOWN } from '../resources/UNDEFINED_DATA';
 import { IMAGE_DATA_AST, IMAGE_DATA_MARKDOWN } from '../resources/IMAGE_DATA';
 import { TABLE_NESTED_BLOCKS_AST, TABLE_NESTED_BLOCKS_MARKDOWN } from '../resources/TABLE_NESTED_BLOCKS';
+import { BLOCKCODE_DATA } from '../resources/BLOCKCODE_DATA';
 
 test('testing  bold  node', () => {
 	const boldRegex = /\*\*testing bold\*\*/gi;
@@ -37,6 +38,12 @@ test('expecting strikethrough node', () => {
 test('expecting block code node', () => {
 	const regex = /`{3,}(.*)\n([\s\S]+?\n)\s*`{3,}\n/gi;
 	const markdownString = new MarkdownRenderer().renderMarkdown(GENERAL_DATA as DocumentNode);
+	expect(markdownString.match(regex).length).toBe(1);
+});
+
+test('expecting block code node with indentation', () => {
+	const regex = /`{3,}(.*)\n([\s\S]+?\n)\s*`{3,}\n/gi;
+	const markdownString = new MarkdownRenderer().renderMarkdown(BLOCKCODE_DATA as DocumentNode);
 	expect(markdownString.match(regex).length).toBe(1);
 });
 


### PR DESCRIPTION
The literal backtick/tilde regexes were causing the markdown editor to crash for code fences containing long runs of whitespace.