### PR TITLE
DEVENGAGE-3180 version corrections

### DIFF
--- a/yeast-html-renderer/package-lock.json
+++ b/yeast-html-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "yeast-html-renderer",
-	"version": "1.0.2",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "yeast-html-renderer",
-			"version": "1.0.2",
+			"version": "1.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^21.0.3",

--- a/yeast-html-renderer/package.json
+++ b/yeast-html-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeast-html-renderer",
-	"version": "1.0.2",
+	"version": "1.0.1",
 	"description": "The yeast HTML renderer project provides a class to render yeast documents as HTML",
 	"exports": {
 		"require": "./src/index.ts",

--- a/yeast-markdown-parser/package-lock.json
+++ b/yeast-markdown-parser/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "yeast-markdown-parser",
-	"version": "1.5.8",
+	"version": "1.5.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "yeast-markdown-parser",
-			"version": "1.5.8",
+			"version": "1.5.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^21.0.3",

--- a/yeast-markdown-parser/package.json
+++ b/yeast-markdown-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeast-markdown-parser",
-	"version": "1.5.8",
+	"version": "1.5.9",
 	"description": "Parses markdown to yeAST (Yuri's Empathetic Arbitrary Syntax Tree) documents",
 	"exports": {
 		"require": "./src/index.ts",


### PR DESCRIPTION
I missed the yeast-markdown-parser version and somehow bumped yeast-html-renderer version by two.  I caught these right after I merged the original PR.